### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,17 @@ impl AsciiVideo {
         let height = r.read_u16::<LittleEndian>()?;
         let frame_count = r.read_u32::<LittleEndian>()? as usize;
 
+        if width == 0 || height == 0 || width > 4096 || height > 4096 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "dimensions out of range, max 4096x4096"));
+        }
+        
+        if frame_count > 100_000 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("too many frames: {} (max {})", frame_count, 100_000),
+            ));
+        }
+        
         // frames
         let mut frames = Vec::with_capacity(frame_count);
         for _ in 0..frame_count {


### PR DESCRIPTION
Fixes an issue where malformed files with extremely large frame counts could cause memory allocation failures.

This change introduces a hard limit of 100,000 frames, which at 30 FPS equals roughly 55 minutes of playback, more than enough for practical use cases. (Lets be honest, no one is watching a full length movie in ASCII art.)

In the future, we should consider rewriting this to support streaming frames directly from a file, so we don’t need to load all frames into memory at once.


Lovely
Louis